### PR TITLE
fix thread-safe issue and a Clear() issue

### DIFF
--- a/src/LRUCache.Tests/LRUCache.Tests.csproj
+++ b/src/LRUCache.Tests/LRUCache.Tests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.13.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.0\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +11,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LRUCache.Tests</RootNamespace>
     <AssemblyName>LRUCache.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,11 +35,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.13.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.13.0\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -46,9 +52,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\LRUCache\LRUCache.csproj">
       <Project>{efaeadff-863f-400e-a45e-6a5d40c97217}</Project>
       <Name>LRUCache</Name>
@@ -57,7 +60,17 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>这台计算机上缺少此项目引用的 NuGet 程序包。使用“NuGet 程序包还原”可下载这些程序包。有关更多信息，请参见 http://go.microsoft.com/fwlink/?LinkID=322105。缺少的文件是 {0}。</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.13.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.0\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/LRUCache.Tests/Tests.cs
+++ b/src/LRUCache.Tests/Tests.cs
@@ -2,7 +2,9 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
+using System.Runtime.Caching;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -12,7 +14,7 @@ namespace LRUCacheTests
     public class Tests
     {
         [Test]
-        public void TestCreate()
+        public void Add_Normal_Normal()
         {
             var cache = new LRUCache<int, string>(capacity: 1000);
             var key = 1;
@@ -22,6 +24,33 @@ namespace LRUCacheTests
             string valueInCache;
             Assert.True(cache.TryGetValue(key, out valueInCache));
             Assert.AreEqual(value, valueInCache, "Value in cache does not match value put in");
+        }
+
+        [Test]
+        public void Clear_AfterFull_CountIsZero()
+        {
+            var cache = new LRUCache<int, string>(capacity: 1000);
+
+            for (int i = 0;i < 1000;i++)
+            {
+                cache.Add(i, i.ToString());
+            }
+            Assert.AreEqual(1000, cache.Count, "Cache Count should be 1000 after init");
+
+            var key = 1;
+            var value = "Hello";
+
+            cache.Clear();
+
+            Assert.AreEqual(0, cache.Count, "Cache Count should be 0 after clear");
+
+            cache.Add(key, value);
+            //cache.TryGetValue(key, out var valueInCache);
+
+            //value = "Hello1";
+
+            Assert.True(cache.TryGetValue(key, out var valueInCache));
+            Assert.AreEqual(value, valueInCache, "Value1 in cache does not match value put in");
         }
     }
 }

--- a/src/LRUCache.Tests/packages.config
+++ b/src/LRUCache.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnit" version="3.13.0" targetFramework="net40" />
+  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net40" />
 </packages>

--- a/src/LRUCache/LRUCache.cs
+++ b/src/LRUCache/LRUCache.cs
@@ -101,9 +101,12 @@ namespace Caching
             CacheNode entry;
             value = default(V);
 
-            if (!this._entries.TryGetValue(key, out entry))
+            lock (this)
             {
-                return false;
+                if (!this._entries.TryGetValue(key, out entry))
+                {
+                    return false;
+                }
             }
 
             if (this._refreshEntries)
@@ -138,7 +141,15 @@ namespace Caching
         public bool TryAdd(K key, V value)
         {
             CacheNode entry;
-            if (!this._entries.TryGetValue(key, out entry))
+
+            var result = false;
+
+            lock (this)
+            {
+                result = this._entries.TryGetValue(key, out entry);
+            }
+
+            if (!result)
             {
                 // Add the entry
                 lock (this)

--- a/src/LRUCache/LRUCache.cs
+++ b/src/LRUCache/LRUCache.cs
@@ -218,6 +218,7 @@ namespace Caching
                 this._entries.Clear();
                 this._head = null;
                 this._tail = null;
+                this._count = 0;
                 return true;
             }
         }


### PR DESCRIPTION
@tejacques The following functions cannot be safely called from two concurrent threads since Dictionary does not seem to be thread-safe: TryAdd,  TryGetValue. 
_count must be reset to zero after Clear called. Otherwise wrong capacity is used or a NRE will throw (calling Clear when capacity is fulled) .